### PR TITLE
Fixed remat visual timing / Switched towards `memory` strat / General cleanup

### DIFF
--- a/examples/dev/litGPT.py
+++ b/examples/dev/litGPT.py
@@ -9,7 +9,7 @@ class Test:
         self.layers = layers
         self.autotune_type = autotune_type
 
-layers = [Test(8, 'runtime')]#, Test(8, 'runtime'), Test(16, 'runtime')]
+layers = [Test(8, 'runtime'), Test(8, 'runtime'), Test(16, 'runtime')]
 
 model_name = 'Llama-2-7b-hf'
 

--- a/examples/dev/nanogpt-block.py
+++ b/examples/dev/nanogpt-block.py
@@ -121,13 +121,13 @@ with torch.device('cuda'):
     print('Results thunder benchmark:')
     traces = [thunder.last_traces(jmodel_def)[-1], thunder.last_traces(jmodel_auto)[-1], thunder.last_backward_traces(jmodel_def)[-1], thunder.last_backward_traces(jmodel_auto)[-1]]
     labels = ['fw_def', 'fw_auto', 'bw_def', 'bw_auto']
-    thunder_fw_bw_benchmark(traces, labels, 50)
+    thunder_fw_bw_benchmark(traces, labels, 5)
 
     print('\n\nResults torch fw bw benchmark:')
     callables = [jmodel_def, jmodel_auto]
     labels = ['def', 'auto']
     inputs = [x, x]
-    torch_fw_bw_benchmark(callables, labels, inputs, 50)
+    torch_fw_bw_benchmark(callables, labels, inputs, 5)
 
     print('\n\n\n\n\n\n')
     print(f'{thunder.last_traces(jmodel_def)[-1]}')

--- a/examples/dev/nanogpt.py
+++ b/examples/dev/nanogpt.py
@@ -6,7 +6,7 @@ from contextlib import nullcontext
 
 warm_up_iters = 50
 
-def test():
+def run():
     # -----------------------------------------------------------------------------
     batch_size = 12
     block_size = 1024
@@ -149,4 +149,4 @@ def test():
     for t in traces:
         print(f'{t}\n############################################')
 
-test()
+run()

--- a/examples/dev/nanogpt.py
+++ b/examples/dev/nanogpt.py
@@ -58,6 +58,7 @@ def test():
     model.to(device)
 
     jmodel_def = thunder.jit(model)
+    # Currently sdpa does not work?
     jmodel_auto = thunder.jit(model, autotune_type='runtime', executors = ['torchcompile', 'nvfuser', 'cudnn', 'torch', 'python'])
 
     # optimizer = model.configure_optimizers(weight_decay=1e-2, learning_rate=1e-4, betas=(0.9, 0.95), device_type=device_type)

--- a/examples/dev/nanogpt.py
+++ b/examples/dev/nanogpt.py
@@ -50,7 +50,7 @@ def test():
     # model init
     gptconf = GPTConfig(
         block_size = block_size, # how far back does the model look? i.e. context size
-        n_layer = 1, n_head = 12, n_embd = 768, # size of the model
+        n_layer = 2, n_head = 12, n_embd = 768, # size of the model
         dropout = 0, # for determinism
         bias = bias,
     )
@@ -59,7 +59,7 @@ def test():
 
     jmodel_def = thunder.jit(model)
     # Currently sdpa does not work?
-    jmodel_auto = thunder.jit(model, autotune_type='runtime', executors = ['torchcompile', 'nvfuser', 'cudnn', 'torch', 'python'])
+    jmodel_auto = thunder.jit(model, autotune_type='memory', executors = ['torchcompile', 'nvfuser', 'cudnn', 'torch', 'python'])
 
     # optimizer = model.configure_optimizers(weight_decay=1e-2, learning_rate=1e-4, betas=(0.9, 0.95), device_type=device_type)
 

--- a/examples/dev/nanogpt.py
+++ b/examples/dev/nanogpt.py
@@ -2,161 +2,153 @@ import torch
 import thunder
 from thunder.benchmarks.utils import thunder_fw_bw_benchmark
 from thunder.tests.nanogpt_model import GPTConfig, GPT
+from contextlib import nullcontext
+import time
+# import os
 
 warm_up_iters = 50
 
-def torch_fw_bw_benchmark(models: list, labels: list, inputs: list, iters: int) -> None:
 
-    for m, input, label in zip(models, inputs, labels):
-        # Warm up
-        for _ in range(warm_up_iters):
-            _, loss = m(input)
-            loss.backward()
+def bench():
+    # -----------------------------------------------------------------------------
+    batch_size = 12
+    block_size = 1024
+    bias = False
+    real_data = False
+    seed = 1337
+    device = 'cuda' # examples: 'cpu', 'cuda', 'cuda:0', 'cuda:1', etc.
+    dtype = 'bfloat16' if torch.cuda.is_available() and torch.cuda.is_bf16_supported() else 'float16' # 'float32' or 'bfloat16' or 'float16'
+    compile = False # use PyTorch 2.0 to compile the model to be faster
+    profile = False # use pytorch profiler, or just simple benchmarking?
+    # exec(open('configurator.py').read()) # overrides from command line or config file
+    # -----------------------------------------------------------------------------
 
+    torch.manual_seed(seed)
+    torch.cuda.manual_seed(seed)
+    torch.backends.cuda.matmul.allow_tf32 = True # allow tf32 on matmul
+    torch.backends.cudnn.allow_tf32 = True # allow tf32 on cudnn
+    device_type = 'cuda' if 'cuda' in device else 'cpu' # for later use in torch.autocast
+    ptdtype = {'float32': torch.float32, 'bfloat16': torch.bfloat16, 'float16': torch.float16}[dtype]
+    ctx = nullcontext() if device_type == 'cpu' else torch.amp.autocast(device_type=device_type, dtype=ptdtype)
+
+    # data loading init
+    if real_data:
+        raise RuntimeError('Not supported')
+        # dataset = 'openwebtext'
+        # data_dir = os.path.join('data', dataset)
+        # train_data = np.memmap(os.path.join(data_dir, 'train.bin'), dtype=np.uint16, mode='r')
+        # def get_batch(split):
+        #     data = train_data # note ignore split in benchmarking script
+        #     ix = torch.randint(len(data) - block_size, (batch_size,))
+        #     x = torch.stack([torch.from_numpy((data[i:i+block_size]).astype(np.int64)) for i in ix])
+        #     y = torch.stack([torch.from_numpy((data[i+1:i+1+block_size]).astype(np.int64)) for i in ix])
+        #     x, y = x.pin_memory().to(device, non_blocking=True), y.pin_memory().to(device, non_blocking=True)
+        #     return x, y
+    else:
+        # alternatively, if fixed data is desired to not care about data loading
+        x = torch.randint(50304, (batch_size, block_size), device=device)
+        y = torch.randint(50304, (batch_size, block_size), device=device)
+        get_batch = lambda split: (x, y)
+
+    # model init
+    gptconf = GPTConfig(
+        block_size = block_size, # how far back does the model look? i.e. context size
+        n_layer = 1, n_head = 12, n_embd = 768, # size of the model
+        dropout = 0, # for determinism
+        bias = bias,
+    )
+    model = GPT(gptconf)
+    model.to(device)
+
+    jmodel_def = thunder.jit(model)
+    jmodel_auto = thunder.jit(model, autotune_type='runtime', executors = ['nvfuser', 'torchcompile', 'sdpa', 'cudnn', 'torch', 'python'])
+
+    optimizer = model.configure_optimizers(weight_decay=1e-2, learning_rate=1e-4, betas=(0.9, 0.95), device_type=device_type)
+
+    if compile:
+        print("Compiling model...")
+        model = torch.compile(model) # pytorch 2.0
+
+    if profile:
+        # useful docs on pytorch profiler:
+        # - tutorial https://pytorch.org/tutorials/intermediate/tensorboard_profiler_tutorial.html
+        # - api https://pytorch.org/docs/stable/profiler.html#torch.profiler.profile
+        wait, warmup, active = 5, 5, 5
+        num_steps = wait + warmup + active
+        with torch.profiler.profile(
+            activities=[torch.profiler.ProfilerActivity.CPU, torch.profiler.ProfilerActivity.CUDA],
+            schedule=torch.profiler.schedule(wait=wait, warmup=warmup, active=active, repeat=1),
+            on_trace_ready=torch.profiler.tensorboard_trace_handler('./bench_log'),
+            record_shapes=False,
+            profile_memory=False,
+            with_stack=False, # incurs an additional overhead, disable if not needed
+            with_flops=True,
+            with_modules=False, # only for torchscript models atm
+        ) as prof:
+
+            X, Y = get_batch('train')
+            for k in range(num_steps):
+                with ctx:
+                    logits, loss = model(X, Y)
+                X, Y = get_batch('train')
+                optimizer.zero_grad(set_to_none=True)
+                loss.backward()
+                optimizer.step()
+                lossf = loss.item()
+                print(f"{k}/{num_steps} loss: {lossf:.4f}")
+
+                prof.step() # notify the profiler at end of each step
+
+    else:
+
+        # simple benchmarking
         torch.cuda.synchronize()
-        start_events = [torch.cuda.Event(enable_timing=True) for _ in range(iters)]
-        end_events = [torch.cuda.Event(enable_timing=True) for _ in range(iters)]
-        stream = torch.cuda.current_stream()
-        max_allocated_bytes = 0
-        for i in range(iters):
-            torch.cuda.reset_peak_memory_stats(torch.cuda.current_device())
-            torch.cuda.empty_cache()
-            torch.cuda._sleep(1_000_000)
+        for stage, num_steps in enumerate([50, 10]): # burnin, then benchmark
+            t0 = time.time()
+            X, Y = get_batch('train')
+            for k in range(num_steps):
+                with ctx:
+                    logits, loss = jmodel_def(X, Y)
+                X, Y = get_batch('train')
+                # optimizer.zero_grad(set_to_none=True)
+                loss.backward()
+                # optimizer.step()
+                lossf = loss.item()
+                print(f"{k}/{num_steps} loss: {lossf:.4f}")
+            torch.cuda.synchronize()
+            t1 = time.time()
+            dt = t1-t0
+            # mfu = model.estimate_mfu(batch_size * 1 * num_steps, dt)
+            if stage == 1:
+                # print(f"time per iteration: {dt/num_steps*1000:.4f}ms, MFU: {mfu*100:.2f}%")
+                print(f"time per iteration default model: {dt/num_steps*1000:.4f}ms")
 
-            start_events[i].record(stream)
-            out = m(input)
-            end_events[i].record(stream)
-
-            max_allocated_bytes = max(
-                max_allocated_bytes, torch.cuda.max_memory_allocated(
-                    torch.cuda.current_device())
-            )
-
+        # simple benchmarking
         torch.cuda.synchronize()
-        tot = [s.elapsed_time(e) for s, e in zip(start_events, end_events)]
-        tot_time = sum(tot) / iters
-        print(f'{label} tot fw time: {tot_time} ms')
-        print(f'{label} max fw allocated memory: {max_allocated_bytes / (2**30)} GB')
+        for stage, num_steps in enumerate([50, 10]): # burnin, then benchmark
+            t0 = time.time()
+            X, Y = get_batch('train')
+            for k in range(num_steps):
+                with ctx:
+                    logits, loss = jmodel_auto(X, Y)
+                X, Y = get_batch('train')
+                # optimizer.zero_grad(set_to_none=True)
+                loss.backward()
+                # optimizer.step()
+                lossf = loss.item()
+                print(f"{k}/{num_steps} loss: {lossf:.4f}")
+            torch.cuda.synchronize()
+            t1 = time.time()
+            dt = t1-t0
+            # mfu = model.estimate_mfu(batch_size * 1 * num_steps, dt)
+            if stage == 1:
+                # print(f"time per iteration: {dt/num_steps*1000:.4f}ms, MFU: {mfu*100:.2f}%")
+                print(f"time per iteration auto model: {dt/num_steps*1000:.4f}ms")
 
-        torch.cuda.synchronize()
-        start_events = [torch.cuda.Event(enable_timing=True) for _ in range(iters)]
-        end_events = [torch.cuda.Event(enable_timing=True) for _ in range(iters)]
-        stream = torch.cuda.current_stream()
-        max_allocated_bytes = 0
-        for i in range(iters):
-            torch.cuda.reset_peak_memory_stats(torch.cuda.current_device())
-            torch.cuda.empty_cache()
-            torch.cuda._sleep(1_000_000)
 
-            _, loss = m(input)
-            loss.backward()
-            start_events[i].record(stream)
-            loss.backward()
-            end_events[i].record(stream)
+        print('\n\nResults thunder benchmark:')
+        traces = [thunder.last_traces(jmodel_def)[-1], thunder.last_traces(jmodel_auto)[-1], thunder.last_backward_traces(jmodel_def)[-1], thunder.last_backward_traces(jmodel_auto)[-1]]
+        labels = ['fw_def', 'fw_auto', 'bw_def', 'bw_auto']
+        thunder_fw_bw_benchmark(traces, labels, 50)
 
-            max_allocated_bytes = max(
-                max_allocated_bytes, torch.cuda.max_memory_allocated(
-                    torch.cuda.current_device())
-            )
-
-        torch.cuda.synchronize()
-        tot = [s.elapsed_time(e) for s, e in zip(start_events, end_events)]
-        tot_time = sum(tot) / iters
-        print(f'{label} tot bw time: {tot_time} ms')
-        print(f'{label} max bw allocated memory: {max_allocated_bytes / (2**30)} GB')
-
-def torch_total_benchmark(models: list, labels: list, inputs: list, iters: int) -> None:
-
-    for m, input, label in zip(models, inputs, labels):
-        # Warm up
-        for _ in range(warm_up_iters):
-            _, loss = m(input)
-            loss.backward()
-
-        start_events = [torch.cuda.Event(enable_timing=True) for _ in range(iters)]
-        end_events = [torch.cuda.Event(enable_timing=True) for _ in range(iters)]
-        torch.cuda.synchronize()
-        stream = torch.cuda.current_stream()
-        max_allocated_bytes = 0
-        for i in range(iters):
-            torch.cuda.reset_peak_memory_stats(torch.cuda.current_device())
-            torch.cuda.empty_cache()
-            torch.cuda._sleep(1_000_000)
-
-            start_events[i].record(stream)
-            _, loss = m(input)
-            loss.backward()
-            end_events[i].record(stream)
-
-            max_allocated_bytes = max(
-                max_allocated_bytes, torch.cuda.max_memory_allocated(
-                    torch.cuda.current_device())
-            )
-
-        torch.cuda.synchronize()
-        tot = [s.elapsed_time(e) for s, e in zip(start_events, end_events)]
-        tot_time = sum(tot) / iters
-        print(f'{label} tot time: {tot_time} ms')
-        print(f'{label} max allocated memory: {max_allocated_bytes / (2**30)} GB')
-
-# -----------------------------------------------------------------------------
-batch_size = 12
-block_size = 1024
-bias = False
-seed = 1337
-device = 'cuda'
-# dtype = 'float16'
-dtype = 'bfloat16' if torch.cuda.is_available() and torch.cuda.is_bf16_supported() else 'float16' # 'float32' or 'bfloat16' or 'float16'
-# -----------------------------------------------------------------------------
-torch.manual_seed(seed)
-torch.cuda.manual_seed(seed)
-torch.backends.cuda.matmul.allow_tf32 = True # allow tf32 on matmul
-torch.backends.cudnn.allow_tf32 = True # allow tf32 on cudnn
-device_type = 'cuda' if 'cuda' in device else 'cpu' # for later use in torch.autocast
-ptdtype = {'float32': torch.float32, 'bfloat16': torch.bfloat16, 'float16': torch.float16}[dtype]
-
-x = torch.randint(50304, (batch_size, block_size), device=device)
-y = torch.randint(50304, (batch_size, block_size), device=device)
-get_batch = lambda split: (x, y)
-
-# model init
-gptconf = GPTConfig(
-    block_size = block_size, # how far back does the model look? i.e. context size
-    n_layer = 1, n_head = 12, n_embd = 768, # size of the model
-    dropout = 0, # for determinism
-    bias = bias,
-)
-model = GPT(gptconf)
-model.to(device)
-
-jmodel_def = thunder.jit(model)
-jmodel_auto = thunder.jit(model, autotune_type='runtime', executors = ['nvfuser', 'torchcompile', 'sdpa', 'cudnn', 'torch', 'python'])
-
-X, Y = get_batch('train')
-# Run compilation
-jmodel_def(x, y)
-jmodel_auto(x, y)
-
-print('Results thunder benchmark:')
-traces = [thunder.last_traces(jmodel_def)[-1], thunder.last_traces(jmodel_auto)[-1], thunder.last_backward_traces(jmodel_def)[-1], thunder.last_backward_traces(jmodel_auto)[-1]]
-labels = ['fw_def', 'fw_auto', 'bw_def', 'bw_auto']
-thunder_fw_bw_benchmark(traces, labels, 50)
-
-print('\n\nResults torch fw bw benchmark:')
-callables = [jmodel_def, jmodel_auto]
-labels = ['def', 'auto']
-inputs = [x, x]
-torch_fw_bw_benchmark(callables, labels, inputs, 50)
-print('\n\nResults torch tot benchmark:')
-torch_total_benchmark(callables, labels, inputs, 50)
-
-print('\n\n\n\n\n\n')
-print(f'{thunder.last_traces(jmodel_def)[-1]}')
-print('###############################################################################')
-print(f'{thunder.last_traces(jmodel_auto)[-1]}')
-
-print('\n\n')
-print(f'{thunder.last_backward_traces(jmodel_def)[-1]}')
-print('###############################################################################')
-print(f'{thunder.last_backward_traces(jmodel_auto)[-1]}')
-
+bench()

--- a/examples/dev/nanogpt.py
+++ b/examples/dev/nanogpt.py
@@ -61,7 +61,7 @@ def bench():
     model.to(device)
 
     jmodel_def = thunder.jit(model)
-    jmodel_auto = thunder.jit(model, autotune_type='runtime', executors = ['nvfuser', 'torchcompile', 'sdpa', 'cudnn', 'torch', 'python'])
+    jmodel_auto = thunder.jit(model, autotune_type='runtime', executors = ['nvfuser', 'sdpa', 'cudnn', 'torch', 'python'])
 
     optimizer = model.configure_optimizers(weight_decay=1e-2, learning_rate=1e-4, betas=(0.9, 0.95), device_type=device_type)
 

--- a/examples/dev/nanogpt.py
+++ b/examples/dev/nanogpt.py
@@ -135,12 +135,14 @@ def test():
             print('\n\nResults torch benchmark:')
             print(f'{label} tot time: {tot_time} ms')
 
-        measure(jmodel_def, 'def')
         measure(jmodel_auto, 'auto')
+        measure(jmodel_def, 'def')
 
         print('\n\nResults thunder benchmark:')
         traces = [thunder.last_traces(jmodel_def)[-1], thunder.last_traces(jmodel_auto)[-1], thunder.last_backward_traces(jmodel_def)[-1], thunder.last_backward_traces(jmodel_auto)[-1]]
+        traces.reverse()
         labels = ['fw_def', 'fw_auto', 'bw_def', 'bw_auto']
+        labels.reverse()
         thunder_fw_bw_benchmark(traces, labels, 5)
 
     traces = [thunder.last_traces(jmodel_def)[-1], thunder.last_traces(jmodel_auto)[-1], thunder.last_backward_traces(jmodel_def)[-1], thunder.last_backward_traces(jmodel_auto)[-1]]

--- a/thunder/backend_optimizer/optimizer.py
+++ b/thunder/backend_optimizer/optimizer.py
@@ -680,11 +680,6 @@ class BackendOptimizer:
                 # Inside groups we should have alwasy tensors as out
                 best_res_time = BenchmarkResult()
                 best_res_mem = BenchmarkResult()
-                worst_res_time = BenchmarkResult()
-                worst_res_mem = BenchmarkResult()
-                # Only for visual
-                worst_res_mem.measure = 0
-                worst_res_time.measure = 0
 
                 # TODO (matteochen): Aggregate them
                 best_placement_time = None
@@ -696,11 +691,9 @@ class BackendOptimizer:
                     nonlocal best_res_time
                     nonlocal best_placement_time
                     nonlocal best_keys_time
-                    nonlocal worst_res_time
                     nonlocal best_res_mem
                     nonlocal best_placement_mem
                     nonlocal best_keys_mem
-                    nonlocal worst_res_mem
                     trc, keys, placements = get_placed_trace(
                         dict_time_strat, increasing_symbols)
                     if self.trace_type == TraceType.BW and self.active_fw_trace is not None:
@@ -716,8 +709,6 @@ class BackendOptimizer:
                         best_res_time.trace = trc
                         best_placement_time = placements
                         best_keys_time = keys
-                    if cost > worst_res_time.tm:
-                        worst_res_time.tm = cost
 
                     if mem < best_res_mem.mem or (mem == best_res_mem.mem and cost < best_res_mem.tm):
                         best_res_mem.tm = cost
@@ -725,8 +716,6 @@ class BackendOptimizer:
                         best_res_mem.trace = trc
                         best_placement_mem = placements
                         best_keys_mem = keys
-                    if mem > worst_res_mem.mem:
-                        worst_res_mem.mem = mem
 
                 start_idx = 0
                 # This is to accomodate the following TODO
@@ -785,11 +774,11 @@ class BackendOptimizer:
                     raise AssertionError("Failed to get best placement")
 
                 log(
-                    f"For group {group_id} best placement with time cost = {best_res_time.tm} ms (worst time = {worst_res_time.tm} ms):\n{best_res_time.trace}",
+                    f"For group {group_id} best placement with time cost = {best_res_time.tm} ms:\n{best_res_time.trace}",
                     level=LogLevel.DEBUG
                 )
                 log(
-                    f"For group {group_id} best placement with mem cost = {best_res_mem.mem / (2**30)} GB (worst mem = {worst_res_mem.mem/(2**30)} GB) is:\n{best_res_mem.trace}",
+                    f"For group {group_id} best placement with mem cost = {best_res_mem.mem / (2**30)} GB:\n{best_res_mem.trace}",
                     level=LogLevel.DEBUG
                 )
 

--- a/thunder/backend_optimizer/optimizer.py
+++ b/thunder/backend_optimizer/optimizer.py
@@ -899,6 +899,15 @@ class BackendOptimizer:
                 ans = pair
         if ans is None:
             raise AssertionError('Best pair not found')
+
+        fw = ans.fw
+        c, m, _ = benchmark_trace(fw, iters=self.benchmark_iters)
+        log(f'Final pair fw: {c} ms - {m / (2**30)} GB\n{fw}', level=LogLevel.INFO)
+        bw = ans.bw
+        c, m, _ = benchmark_trace(bw, iters=self.benchmark_iters)
+        log(f'Final pair bw: {c} ms - {m / (2**30)} GB\n{bw}', level=LogLevel.INFO)
+
+
         # To debug this: the traces that we will received in the remat call in <split_forward_backward> should be the same as these and runtime should be in line with the best pair time.
         # The pairs above are traces with no remat call (in order to be called later on) but their tracking time are made with traces gone under the remat call
         return ans.fw, ans.bw
@@ -1187,7 +1196,7 @@ def benchmark_trace(
             torch.cuda.synchronize()
             times = [s.elapsed_time(e)
                      for s, e in zip(start_events, end_events)]
-            # print(f'times: {times}')
+            print(f'times: {times}')
             tot_time = sum(times) / iters
             return tot_time, max_allocated_bytes, out
         except Exception as e:

--- a/thunder/backend_optimizer/optimizer.py
+++ b/thunder/backend_optimizer/optimizer.py
@@ -1051,7 +1051,7 @@ class BackendOptimizer:
                     # Used the computed benchmark from above
                     if time_result.mem < memory_result.mem:
                         log(
-                            f"out candidate mem: (fw){forward_memory / (2**30)} GB, (bw){time_result.mem / (2**30)} GB", level=LogLevel.INFO)
+                            f"out candidate mem from time res: (fw){forward_memory / (2**30)} GB (fw){forward_time} ms, (bw){time_result.mem / (2**30)} GB (bw){time_result.tm} ms", level=LogLevel.INFO)
                         self.out.append(
                             FinalOutputCandidates(
                                 fw=self.active_fw_trace,
@@ -1061,7 +1061,7 @@ class BackendOptimizer:
                         )
                     else:
                         log(
-                            f"out candidate mem: (fw){forward_memory / (2**30)} GB, (bw){memory_result.mem / (2**30)} GB", level=LogLevel.INFO)
+                            f"out candidate mem from time res: (fw){forward_memory / (2**30)} GB (fw){forward_time} ms, (bw){memory_result.mem / (2**30)} GB (bw){memory_result.tm} ms", level=LogLevel.INFO)
                         self.out.append(
                             FinalOutputCandidates(
                                 fw=self.active_fw_trace,

--- a/thunder/backend_optimizer/optimizer.py
+++ b/thunder/backend_optimizer/optimizer.py
@@ -453,7 +453,7 @@ class BackendOptimizer:
     def can_executor_execute(self, ex: Executor, bsym: BoundSymbol) -> bool:
         try:
             return ex.can_execute(bsym)
-        except:
+        except Exception:
             return False
 
     # For each fusion executor in the input list, find the best trace dispatching for each executor

--- a/thunder/backend_optimizer/optimizer.py
+++ b/thunder/backend_optimizer/optimizer.py
@@ -195,8 +195,6 @@ class BackendOptimizer:
 
         swapmap: dict[Variable, Proxy] = {}
 
-        # During the fusion pass and CSE optimizatons some args in trace regions could be different from the cached args. Restore the correct arguments
-        # https://pytorch-lightning.slack.com/archives/C06QA9M8L3C/p1720732254341999
         def restore_correct_args(trace_in: TraceCtx):
             def args_eq(a, b) -> bool:
                 if len(a) != len(b):

--- a/thunder/backend_optimizer/optimizer.py
+++ b/thunder/backend_optimizer/optimizer.py
@@ -3,6 +3,7 @@ from enum import Enum
 from itertools import chain
 from thunder.core.dtypes import dtype, is_boolean_dtype
 from thunder.core.prims import PrimIDs
+from thunder.core.rematerialization import rematerialize_forward_and_backward
 from thunder.core.utils import check, safe_map_flat
 from thunder.core.baseutils import BoundSymbolInterface
 from thunder.core.proxies import CollectionProxy, FloatProxy, IntegerProxy, Proxy, TensorProxy, variableify, Variable
@@ -1012,6 +1013,14 @@ class BackendOptimizer:
             # The current fw trace is set by the caller and we take it as is. All current bw traces optimizations are made with the fw trace set by the caller
             forward_time, forward_memory, _ = benchmark_trace(
                 self.active_fw_trace, self.benchmark_iters)
+
+            test_fw, test_bw = rematerialize_forward_and_backward(self.active_fw_trace, time_result.trace)
+            c, m, _ = benchmark_trace(test_fw, iters=self.benchmark_iters)
+            print(f'Before out candidate fw: {c} ms - {m / (2**30)} GB')
+            c, m, _ = benchmark_trace(test_bw, iters=self.benchmark_iters)
+            print(f'Before out candidate bw: {c} ms - {m / (2**30)} GB')
+
+
             match self.optimizer_type:
                 case OptimizerType.RUNTIME:
                     # Used the computed benchmark from above

--- a/thunder/backend_optimizer/optimizer.py
+++ b/thunder/backend_optimizer/optimizer.py
@@ -3,7 +3,6 @@ from enum import Enum
 from itertools import chain
 from thunder.core.dtypes import dtype, is_boolean_dtype
 from thunder.core.prims import PrimIDs
-from thunder.core.rematerialization import rematerialize_forward_and_backward
 from thunder.core.utils import check, safe_map_flat
 from thunder.core.baseutils import BoundSymbolInterface
 from thunder.core.proxies import CollectionProxy, FloatProxy, IntegerProxy, Proxy, TensorProxy, variableify, Variable
@@ -1013,6 +1012,9 @@ class BackendOptimizer:
             # The current fw trace is set by the caller and we take it as is. All current bw traces optimizations are made with the fw trace set by the caller
             forward_time, forward_memory, _ = benchmark_trace(
                 self.active_fw_trace, self.benchmark_iters)
+
+
+            from thunder.core.rematerialization import rematerialize_forward_and_backward
 
             test_fw, test_bw = rematerialize_forward_and_backward(self.active_fw_trace, time_result.trace)
             c, m, _ = benchmark_trace(test_fw, iters=self.benchmark_iters)

--- a/thunder/backend_optimizer/optimizer.py
+++ b/thunder/backend_optimizer/optimizer.py
@@ -1323,6 +1323,7 @@ def benchmark_trace(
             t, m, answer = compute_time_cost_ms(executable, execuhtable_str, iters, *input_args)
     except Exception as e:
         # https://github.com/Lightning-AI/lightning-thunder/issues/664
+        # Seems that this patch never work ...
         print(f"Exception:\n{e}")
         if "call_method UserDefinedObjectVariable(set) __contains__ [UserDefinedObjectVariable()] {}" in str(e) and not nvsight:
             print(

--- a/thunder/backend_optimizer/optimizer.py
+++ b/thunder/backend_optimizer/optimizer.py
@@ -1156,7 +1156,7 @@ def benchmark_trace(
             print(f"#NVSIGHT FN EXECUTION FAILED:\n{trc}")
             raise e
 
-    def compute_time_cost_ms(fn: Callable, iters: int, *args) -> tuple[float, float, Any]:
+    def compute_time_cost_ms(fn: Callable, repr: str, iters: int, *args) -> tuple[float, float, Any]:
         try:
             warm_up_iters = 50
             out = None
@@ -1200,10 +1200,7 @@ def benchmark_trace(
             tot_time = sum(times) / iters
             return tot_time, max_allocated_bytes, out
         except Exception as e:
-            import inspect
-
-            trc = inspect.getsource(fn)
-            print(f"#FN EXECUTION FAILED:\n{trc}")
+            print(f"#FN EXECUTION FAILED:\n{repr}")
             raise e
 
     def print_input_args(args, level=0, show_content=False):
@@ -1349,6 +1346,7 @@ def benchmark_trace(
     trace_tok = set_tracectx(trace)
 
     # Obtain the python executable string
+    execuhtable_str = trace.python()
     executable = trace.python_callable()
     if show_func:
         print(inspect.getsource(executable))
@@ -1360,7 +1358,7 @@ def benchmark_trace(
         if nvsight:
             t, m, answer = compute_time_cost_nvsight(executable, iters, *input_args)
         else:
-            t, m, answer = compute_time_cost_ms(executable, iters, *input_args)
+            t, m, answer = compute_time_cost_ms(executable, execuhtable_str, iters, *input_args)
     except Exception as e:
         # https://github.com/Lightning-AI/lightning-thunder/issues/664
         print(f"Exception:\n{e}")

--- a/thunder/executors/torch_autograd.py
+++ b/thunder/executors/torch_autograd.py
@@ -480,5 +480,19 @@ def split_forward_backward(computation_trc: TraceCtx, compile_data, compile_stat
                 compile_stats.last_backward_traces += bw_traces
 
             return fw_extrace, bw_extrace
+        except RuntimeError as e:
+            print(f'Exception occured: {e}')
+            # Restore before calling split
+            compile_data.executors_list = list(cached_executor_list)
+
+            log(
+                    f"================================================================================ Before Autotune Tuning: exception occured, not autotuned split_forward_backward from {executors_candidates}", level=LogLevel.DEBUG)
+            primal_trace, fw_extrace, bw_extrace, fw_traces, bw_traces = split()
+            if compile_stats is not None:
+                compile_stats.last_traces.append(primal_trace)
+                compile_stats.last_traces += fw_traces
+                compile_stats.last_backward_traces += bw_traces
+
+            return fw_extrace, bw_extrace
     else:
         return split()

--- a/thunder/executors/torch_autograd.py
+++ b/thunder/executors/torch_autograd.py
@@ -360,6 +360,8 @@ def split_forward_backward(computation_trc: TraceCtx, compile_data, compile_stat
     if autotune_type is not None:
         cached_executor_list = list(compile_data.executors_list)
         try:
+            # disable this part for now
+            raise RuntimeError('Disabled')
             is_tuned = False
 
             # We are interested to save the best_*s at the last iteration over the executors_candidates dict as the last

--- a/thunder/executors/torch_autograd.py
+++ b/thunder/executors/torch_autograd.py
@@ -361,7 +361,7 @@ def split_forward_backward(computation_trc: TraceCtx, compile_data, compile_stat
         cached_executor_list = list(compile_data.executors_list)
         try:
             # disable this part for now
-            raise RuntimeError('Disabled')
+            # raise RuntimeError('Disabled')
             is_tuned = False
 
             # We are interested to save the best_*s at the last iteration over the executors_candidates dict as the last
@@ -378,20 +378,21 @@ def split_forward_backward(computation_trc: TraceCtx, compile_data, compile_stat
             for i, (ex_type, ex_list) in enumerate(executors_candidates.items()):
                 log(
                         f"================================================================================ Before Autotune Tuning: Optimizing {ex_type}",
-                        level=LogLevel.DEBUG)
+                        level=LogLevel.INFO)
                 # Search in the requested executor list if one or more than one options for a know multiple executable region is available
                 to_benchmark = [ex for ex in cached_executor_list if ex.name in ex_list]
 
                 if not to_benchmark:
                     log(
                             f"================================================================================ Before Autotune Tuning: Skipping optimization for {ex_type} as not requested.",
-                            level=LogLevel.DEBUG)
+                            level=LogLevel.INFO)
 
                 for e in to_benchmark:
                     compile_data.executors_list = [ex for ex in cached_executor_list if ex not in to_benchmark]
+                    # Make it with most priority
                     compile_data.executors_list.insert(0, e)
                     log(
-                            f"================================================================================ Before Autotune Tuning: Testing compile data executors: {compile_data.executors_list}", level=LogLevel.DEBUG)
+                            f"================================================================================ Before Autotune Tuning: Testing compile data executors: {compile_data.executors_list}", level=LogLevel.INFO)
 
                     primal_trace, fw_extrace, bw_extrace, fw_traces, bw_traces = split()
                     time_fw, mem_fw, _ = benchmark_trace(fw_extrace, iters=10, apply_del_last_used=False)
@@ -399,11 +400,11 @@ def split_forward_backward(computation_trc: TraceCtx, compile_data, compile_stat
                     tot_time = time_fw + time_bw
                     tot_mem = mem_fw + mem_bw
                     log(
-                            f"================================================================================ Before Autotune Tuning: Benchmark {ex_type} options: {e.name}. Time fw = {time_fw} ms - Time bw = {time_bw} ms - Mem fw = {mem_fw / (2**30)} GB - Mem bw = {mem_bw / (2**30)} GB", level=LogLevel.DEBUG)
+                            f"================================================================================ Before Autotune Tuning: Benchmark {ex_type} options: {e.name}. Time fw = {time_fw} ms - Time bw = {time_bw} ms - Mem fw = {mem_fw / (2**30)} GB - Mem bw = {mem_bw / (2**30)} GB", level=LogLevel.INFO)
                     log(
-                            f"================================================================================ Before Autotune Tuning: Benchmark {ex_type} options: {e.name}. Time = {tot_time} ms - Mem = {tot_mem / (2**30)} GB", level=LogLevel.DEBUG)
-                    log(f'Fw trace:\n{fw_extrace}', level=LogLevel.DEBUG)
-                    log(f'Bw trace:\n{bw_extrace}', level=LogLevel.DEBUG)
+                            f"================================================================================ Before Autotune Tuning: Benchmark {ex_type} options: {e.name}. Time = {tot_time} ms - Mem = {tot_mem / (2**30)} GB", level=LogLevel.INFO)
+                    log(f'Fw trace:\n{fw_extrace}', level=LogLevel.INFO)
+                    log(f'Bw trace:\n{bw_extrace}', level=LogLevel.INFO)
 
                     benchmark_cost = tot_time if autotune_type == OptimizerType.RUNTIME else tot_mem
                     if benchmark_cost < best_cost:
@@ -423,10 +424,10 @@ def split_forward_backward(computation_trc: TraceCtx, compile_data, compile_stat
 
                 c, m , _ = benchmark_trace(best_fw_extrace, iters=10, apply_del_last_used=False)
                 log(
-                        f"================================================================================ Before Autotune Tuning: Benchmark {ex_type} best fw_extrace (time = {c}, mem = {m}):\n{best_fw_extrace}", level=LogLevel.DEBUG)
+                        f"================================================================================ Before Autotune Tuning: Benchmark {ex_type} best fw_extrace (time = {c}, mem = {m}):\n{best_fw_extrace}", level=LogLevel.INFO)
                 c, m , _ = benchmark_trace(best_bw_extrace, iters=10, apply_del_last_used=False)
                 log(
-                        f"================================================================================ Before Autotune Tuning: Benchmark {ex_type} best bw_extrace (time = {c}, mem = {m}):\n{best_bw_extrace}", level=LogLevel.DEBUG)
+                        f"================================================================================ Before Autotune Tuning: Benchmark {ex_type} best bw_extrace (time = {c}, mem = {m}):\n{best_bw_extrace}", level=LogLevel.INFO)
 
                 # Update the executor list with the winner executor for the current ex_type
                 cached_executor_list = [ex for ex in cached_executor_list if ex not in to_benchmark]
@@ -435,7 +436,7 @@ def split_forward_backward(computation_trc: TraceCtx, compile_data, compile_stat
                     cached_executor_list.insert(0, best_executor)
                 best_executor = None
                 log(
-                        f"================================================================================ Before Autotune Tuning: Benchmark {ex_type}, new executor list: {cached_executor_list}", level=LogLevel.DEBUG)
+                        f"================================================================================ Before Autotune Tuning: Benchmark {ex_type}, new executor list: {cached_executor_list}", level=LogLevel.INFO)
 
                 # Update the compile stats on the last iter
                 if i == len(executors_candidates)-1:
@@ -445,7 +446,7 @@ def split_forward_backward(computation_trc: TraceCtx, compile_data, compile_stat
                         compile_data.executors_list = list(cached_executor_list)
 
                         log(
-                                f"================================================================================ Before Autotune Tuning: autotuned split_forward_backward from {executors_candidates}", level=LogLevel.DEBUG)
+                                f"================================================================================ Before Autotune Tuning: autotuned split_forward_backward from {executors_candidates}", level=LogLevel.INFO)
                         if compile_stats is not None:
                             compile_stats.last_traces.append(best_primal_trace)
                             compile_stats.last_traces += best_fw_traces
@@ -458,7 +459,7 @@ def split_forward_backward(computation_trc: TraceCtx, compile_data, compile_stat
                         compile_data.executors_list = list(cached_executor_list)
 
                         log(
-                                f"================================================================================ Before Autotune Tuning: not autotuned split_forward_backward from {executors_candidates}", level=LogLevel.DEBUG)
+                                f"================================================================================ Before Autotune Tuning: not autotuned split_forward_backward from {executors_candidates}", level=LogLevel.INFO)
                         primal_trace, fw_extrace, bw_extrace, fw_traces, bw_traces = split()
                         if compile_stats is not None:
                             compile_stats.last_traces.append(primal_trace)
@@ -472,7 +473,7 @@ def split_forward_backward(computation_trc: TraceCtx, compile_data, compile_stat
             compile_data.executors_list = list(cached_executor_list)
 
             log(
-                    f"================================================================================ Before Autotune Tuning: exception occured, not autotuned split_forward_backward from {executors_candidates}", level=LogLevel.DEBUG)
+                    f"================================================================================ Before Autotune Tuning: exception occured, not autotuned split_forward_backward from {executors_candidates}", level=LogLevel.INFO)
             primal_trace, fw_extrace, bw_extrace, fw_traces, bw_traces = split()
             if compile_stats is not None:
                 compile_stats.last_traces.append(primal_trace)
@@ -486,7 +487,7 @@ def split_forward_backward(computation_trc: TraceCtx, compile_data, compile_stat
             compile_data.executors_list = list(cached_executor_list)
 
             log(
-                    f"================================================================================ Before Autotune Tuning: exception occured, not autotuned split_forward_backward from {executors_candidates}", level=LogLevel.DEBUG)
+                    f"================================================================================ Before Autotune Tuning: exception occured, not autotuned split_forward_backward from {executors_candidates}", level=LogLevel.INFO)
             primal_trace, fw_extrace, bw_extrace, fw_traces, bw_traces = split()
             if compile_stats is not None:
                 compile_stats.last_traces.append(primal_trace)

--- a/thunder/executors/torch_autograd.py
+++ b/thunder/executors/torch_autograd.py
@@ -248,12 +248,12 @@ def split_forward_backward(computation_trc: TraceCtx, compile_data, compile_stat
 
         # TODO Restore request for no rematerialization
         c, m, _ = benchmark_trace(fw_extrace, iters=5)
-        log(f'before remat fw trace time = {c}, mem = {m}', level=LogLevel.INFO)
+        log(f'before remat fw trace time = {c}, mem = {m}\n{fw_extrace}', level=LogLevel.INFO)
         c, m, _ = benchmark_trace(bw_extrace, iters=5)
         log(f'before remat bw trace time = {c}, mem = {m}', level=LogLevel.INFO)
         fw_extrace, bw_extrace = rematerialize_forward_and_backward(fw_extrace, bw_extrace)
         c, m, _ = benchmark_trace(fw_extrace, iters=5)
-        log(f'after remat fw trace time = {c}, mem = {m}', level=LogLevel.INFO)
+        log(f'after remat fw trace time = {c}, mem = {m}\n{fw_extrace}', level=LogLevel.INFO)
         c, m, _ = benchmark_trace(bw_extrace, iters=5)
         log(f'after remat bw trace time = {c}, mem = {m}', level=LogLevel.INFO)
         fw_traces.append(fw_extrace)

--- a/thunder/executors/torch_autograd.py
+++ b/thunder/executors/torch_autograd.py
@@ -247,14 +247,14 @@ def split_forward_backward(computation_trc: TraceCtx, compile_data, compile_stat
         visualizer.set_bw_optimized_trace(bw_extrace)
 
         # TODO Restore request for no rematerialization
-        c, m, _ = benchmark_trace(fw_extrace, iters=50)
+        c, m, _ = benchmark_trace(fw_extrace, iters=5)
         log(f'before remat fw trace time = {c}, mem = {m}', level=LogLevel.INFO)
-        c, m, _ = benchmark_trace(bw_extrace, iters=50)
+        c, m, _ = benchmark_trace(bw_extrace, iters=5)
         log(f'before remat bw trace time = {c}, mem = {m}', level=LogLevel.INFO)
         fw_extrace, bw_extrace = rematerialize_forward_and_backward(fw_extrace, bw_extrace)
-        c, m, _ = benchmark_trace(fw_extrace, iters=50)
+        c, m, _ = benchmark_trace(fw_extrace, iters=5)
         log(f'after remat fw trace time = {c}, mem = {m}', level=LogLevel.INFO)
-        c, m, _ = benchmark_trace(bw_extrace, iters=50)
+        c, m, _ = benchmark_trace(bw_extrace, iters=5)
         log(f'after remat bw trace time = {c}, mem = {m}', level=LogLevel.INFO)
         fw_traces.append(fw_extrace)
         bw_traces.append(bw_extrace)


### PR DESCRIPTION
Switching towards a memory strategy enhance both runtime and memory consumption

[nanogpt-a100-0bias-4l.txt](https://github.com/user-attachments/files/16467746/nanogpt-a100-0bias-4l.txt)
